### PR TITLE
Update Makefile VERSION. Auto versioning from git tags.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PKG=github.com/nifcloud/nifcloud-additional-storage-csi-driver
 IMAGE?=ghcr.io/nifcloud/nifcloud-additional-storage-csi-driver
-VERSION=v0.1.0
+VERSION=$(shell git describe --tags --dirty --match="v*")
 GIT_COMMIT?=$(shell git rev-parse HEAD)
 BUILD_DATE?=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS?="-X ${PKG}/pkg/driver.driverVersion=${VERSION} -X ${PKG}/pkg/driver.gitCommit=${GIT_COMMIT} -X ${PKG}/pkg/driver.buildDate=${BUILD_DATE} -s -w"


### PR DESCRIPTION
## Summary

- Auto versioning from git tags.
  - Equals https://github.com/nifcloud/nifcloud-cloud-controller-manager/blob/bc8603f5e9e42b45d814447885f1d167e1aaf909/Makefile#L3
 
## Test

```sh
$ git tag v0.1.2
$ make build
$ ./bin/nifcloud-additional-storage-csi-driver --version
{
  "driverVersion": "v0.1.2",
  "gitCommit": "3c27e06d6eb90fe3ea3b79abd6ad647c33928ccb",
  "buildDate": "2023-09-04T11:02:29Z",
  "goVersion": "go1.20.4",
  "compiler": "gc",
  "platform": "linux/amd64"
}
```
 