### PR TITLE
Fix TODO accounting type

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,21 @@ Storage type (See https://pfs.nifcloud.com/service/disk.htm)
 
 standard-flash-a
 
+### accountingType
+
+#### description
+
+Accounting type (See https://pfs.nifcloud.com/service/disk.htm)
+
+#### values
+
+- monthly
+- hourly
+
+#### default
+
+hourly
+
 ## Installation
 
 1. Create Secret resource with an NIFCLOUD access key id and secret access key.

--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -7,7 +7,8 @@ const (
 
 // constants of keys in volume parameters
 const (
-	VolumeTypeKey = "type"
+	VolumeTypeKey     = "type"
+	AccountingTypeKey = "accountingtype"
 )
 
 // constants for default command line flag values

--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -1,8 +1,16 @@
 package driver
 
+// constants of keys in PublishContext
+const (
+	DevicePathKey = "devicePath"
+)
+
+// constants of keys in volume parameters
+const (
+	VolumeTypeKey = "type"
+)
+
 // constants for default command line flag values
 const (
 	DefaultCSIEndpoint = "unix://tmp/csi.sock"
-	VolumeTypeKey      = "type"
-	DevicePathKey      = "devicePath"
 )

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -435,19 +435,19 @@ func newCreateVolumeResponse(disk *cloud.Disk) *csi.CreateVolumeResponse {
 }
 
 func getVolSizeBytes(req *csi.CreateVolumeRequest) (int64, error) {
-	var volSizeBytes int64
 	capRange := req.GetCapacityRange()
 	if capRange == nil {
-		volSizeBytes = cloud.DefaultVolumeSize
-	} else {
-		volSizeBytes, err := util.RoundUpBytes(capRange.GetRequiredBytes())
-		if err != nil {
-			return 0, status.Errorf(codes.InvalidArgument, "Failed to round-up volume size: %v", err)
-		}
-		maxVolSize := capRange.GetLimitBytes()
-		if maxVolSize > 0 && maxVolSize < volSizeBytes {
-			return 0, status.Error(codes.InvalidArgument, "After round-up, volume size exceeds the limit specified")
-		}
+		return cloud.DefaultVolumeSize, nil
 	}
+
+	volSizeBytes, err := util.RoundUpBytes(capRange.GetRequiredBytes())
+	if err != nil {
+		return 0, status.Errorf(codes.InvalidArgument, "Failed to round-up volume size: %v", err)
+	}
+	maxVolSize := capRange.GetLimitBytes()
+	if maxVolSize > 0 && maxVolSize < volSizeBytes {
+		return 0, status.Error(codes.InvalidArgument, "After round-up, volume size exceeds the limit specified")
+	}
+
 	return volSizeBytes, nil
 }


### PR DESCRIPTION
## Summary

- Fix TODO set accounting type from diskoptions
- Refactor constants by diskoptions and others
- Dependents #32

## Review

- [x] Merged #32
- [x] All checks have passed
- [x] Check Result

## Result

### accountingType blank 

```sh
$ cat storageclass_blank.yml 
---

kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: standard-flash-a-blank
provisioner: additional-storage.csi.nifcloud.com
volumeBindingMode: WaitForFirstConsumer
parameters:
  csi.storage.k8s.io/fstype: ext4
  type: standard-flash-a
allowVolumeExpansion: true
```

```sh
$ cat statefulset_blank.yml 
---

apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: test-blank
spec:
  serviceName: "nginx"
  replicas: 2
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: k8s.gcr.io/nginx-slim:0.8
        ports:
        - containerPort: 80
          name: web
        volumeMounts:
        - name: www
          mountPath: /usr/share/nginx/html
  volumeClaimTemplates:
  - metadata:
      name: www
    spec:
      accessModes: [ "ReadWriteOnce" ]
      storageClassName: standard-flash-a-blank
      resources:
        requests:
          storage: 100Gi
```

![pv_blank](https://github.com/nifcloud/nifcloud-additional-storage-csi-driver/assets/2944768/e8f733d6-9288-4514-9c68-9688a4c9f3ab)

### accountingType hourly

```sh
$ diff storageclass_blank.yml storageclass_hourly.yml 
6c6
<   name: standard-flash-a-blank
---
>   name: standard-flash-a-hourly
11a12
>   accountingType: hourly
```

```sh
$ diff statefulset_blank.yml statefulset_hourly.yml
6c6
<   name: test-blank
---
>   name: test-hourly
32c32
<       storageClassName: standard-flash-a-blank
---
>       storageClassName: standard-flash-a-hourly
```

![pv_hourly](https://github.com/nifcloud/nifcloud-additional-storage-csi-driver/assets/2944768/51101279-ef1a-4518-8326-85bb90e784b1)


### accountingType monthly

```sh
$ diff storageclass_blank.yml storageclass_monthly.yml 
6c6
<   name: standard-flash-a-blank
---
>   name: standard-flash-a-monthly
11a12
>   accountingType: monthly
```

```sh
$ diff statefulset_blank.yml statefulset_monthly.yml
6c6
<   name: test-blank
---
>   name: test-monthly
32c32
<       storageClassName: standard-flash-a-blank
---
>       storageClassName: standard-flash-a-monthly
```

![pv_monthly](https://github.com/nifcloud/nifcloud-additional-storage-csi-driver/assets/2944768/50d69e15-b65b-4b67-a342-9de1427b5134)

