### PR TITLE
Fix return initial zero volume size

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -435,19 +435,19 @@ func newCreateVolumeResponse(disk *cloud.Disk) *csi.CreateVolumeResponse {
 }
 
 func getVolSizeBytes(req *csi.CreateVolumeRequest) (int64, error) {
-	var volSizeBytes int64
 	capRange := req.GetCapacityRange()
 	if capRange == nil {
-		volSizeBytes = cloud.DefaultVolumeSize
-	} else {
-		volSizeBytes, err := util.RoundUpBytes(capRange.GetRequiredBytes())
-		if err != nil {
-			return 0, status.Errorf(codes.InvalidArgument, "Failed to round-up volume size: %v", err)
-		}
-		maxVolSize := capRange.GetLimitBytes()
-		if maxVolSize > 0 && maxVolSize < volSizeBytes {
-			return 0, status.Error(codes.InvalidArgument, "After round-up, volume size exceeds the limit specified")
-		}
+		return cloud.DefaultVolumeSize, nil
 	}
+
+	volSizeBytes, err := util.RoundUpBytes(capRange.GetRequiredBytes())
+	if err != nil {
+		return 0, status.Errorf(codes.InvalidArgument, "Failed to round-up volume size: %v", err)
+	}
+	maxVolSize := capRange.GetLimitBytes()
+	if maxVolSize > 0 && maxVolSize < volSizeBytes {
+		return 0, status.Error(codes.InvalidArgument, "After round-up, volume size exceeds the limit specified")
+	}
+
 	return volSizeBytes, nil
 }


### PR DESCRIPTION
## Summary

- Fix bug by #30
- Function `getVolSizeBytes` returns initial `volSizeBytes` (=0)
  - It requests '000'GiB on CreateVolume and response `Client.InvalidParameterTooSmall.Size`

## Before/After

### Before

```
I0111 09:20:03.299730       1 controller.go:117] create volume in east-12 zone
E0111 09:20:18.876685       1 driver.go:76] GRPC error: rpc error: code = Internal desc = Could not create volume "pvc-3ea25acb-591b-464f-b976-089f50132c72
": could not create NIFCLOUD additional storage: operation error computing: CreateVolume, exceeded maximum number of attempts, 3, https response error Stat
usCode: 500, RequestID: 42d8da3c-9f4a-426a-b9c5-dab24178279a, api error Client.InvalidParameterTooSmall.Size: Volume of '000'GiB is too small; minimum is 1
00GiB.
```

### After

```
I0111 09:38:09.360219       1 controller.go:117] create volume in east-12 zone
```

## Review

- [x] All checks have passed