### PR TITLE
Feature nifcloud sdk debug log

### DIFF
--- a/charts/nifcloud-additional-storage-csi-driver/templates/controller.yaml
+++ b/charts/nifcloud-additional-storage-csi-driver/templates/controller.yaml
@@ -47,6 +47,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --endpoint=$(CSI_ENDPOINT)
+            {{- if .Values.controller.sdkDebugLog }}
+            - --nifcloud-sdk-debug-log=true
+            {{- end}}
             - --logtostderr
             - --v={{ .Values.controller.logLevel }}
           env:

--- a/charts/nifcloud-additional-storage-csi-driver/templates/node.yaml
+++ b/charts/nifcloud-additional-storage-csi-driver/templates/node.yaml
@@ -44,6 +44,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --endpoint=$(CSI_ENDPOINT)
+            {{- if .Values.node.sdkDebugLog }}
+            - --nifcloud-sdk-debug-log=true
+            {{- end}}
             - --logtostderr
             - --v={{ .Values.controller.logLevel }}
           env:

--- a/charts/nifcloud-additional-storage-csi-driver/values.yaml
+++ b/charts/nifcloud-additional-storage-csi-driver/values.yaml
@@ -40,6 +40,7 @@ controller:
   securityContext:
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
+  sdkDebugLog: false
   logLevel: 2
   resources:
     requests:
@@ -76,6 +77,7 @@ node:
   securityContext:
     privileged: true
     readOnlyRootFilesystem: true
+  sdkDebugLog: false
   logLevel: 2
   resources:
     requests:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,12 +11,14 @@ import (
 
 func main() {
 	var (
-		version  bool
-		endpoint string
+		version             bool
+		endpoint            string
+		nifcloudSdkDebugLog bool
 	)
 
 	flag.BoolVar(&version, "version", false, "Print the version and exit.")
 	flag.StringVar(&endpoint, "endpoint", driver.DefaultCSIEndpoint, "CSI Endpoint")
+	flag.BoolVar(&nifcloudSdkDebugLog, "nifcloud-sdk-debug-log", false, "To enable the nifcloud debug log level (default to false).")
 
 	klog.InitFlags(nil)
 	flag.Parse()
@@ -32,6 +34,7 @@ func main() {
 
 	drv, err := driver.NewDriver(
 		driver.WithEndpoint(endpoint),
+		driver.WithNifcloudSdkDebugLog(nifcloudSdkDebugLog),
 	)
 	if err != nil {
 		klog.Fatalln(err)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/nifcloud/nifcloud-additional-storage-csi-driver
 go 1.20
 
 require (
+	github.com/aws/aws-sdk-go-v2 v1.17.4
 	github.com/aws/smithy-go v1.14.0
 	github.com/container-storage-interface/spec v1.8.0
 	github.com/nifcloud/nifcloud-sdk-go v1.21.0
@@ -17,7 +18,6 @@ require (
 )
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.17.4 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/smithy-go"
 	"github.com/nifcloud/nifcloud-additional-storage-csi-driver/pkg/util"
 	"github.com/nifcloud/nifcloud-sdk-go/nifcloud"
@@ -154,11 +155,18 @@ type cloud struct {
 var _ Cloud = &cloud{}
 
 // NewCloud creates the cloud object.
-func NewCloud() (Cloud, error) {
+func NewCloud(nifcloudSdkDebugLog bool) (Cloud, error) {
 	accessKeyID := os.Getenv("NIFCLOUD_ACCESS_KEY_ID")
 	secretAccessKey := os.Getenv("NIFCLOUD_SECRET_ACCESS_KEY")
 	region := os.Getenv("NIFCLOUD_REGION")
 	cfg := nifcloud.NewConfig(accessKeyID, secretAccessKey, region)
+
+	if nifcloudSdkDebugLog {
+		cfg.ClientLogMode = aws.LogRequestWithBody | aws.LogRequestEventMessage |
+			aws.LogResponseWithBody | aws.LogResponseEventMessage |
+			aws.LogRetries
+	}
+
 	return &cloud{
 		region:    region,
 		computing: computing.NewFromConfig(cfg),

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -36,8 +36,8 @@ type controllerService struct {
 	instanceID string
 }
 
-func newControllerService(instanceID string) controllerService {
-	cloud, err := cloud.NewCloud()
+func newControllerService(driverOptions *DriverOptions, instanceID string) controllerService {
+	cloud, err := cloud.NewCloud(driverOptions.nifcloudSdkDebugLog)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -30,7 +30,8 @@ type Driver struct {
 
 // DriverOptions is option for CSI driver.
 type DriverOptions struct {
-	endpoint string
+	endpoint            string
+	nifcloudSdkDebugLog bool
 }
 
 // NewDriver creates the new CSI driver
@@ -43,15 +44,16 @@ func NewDriver(options ...func(*DriverOptions)) (*Driver, error) {
 	}
 
 	driverOptions := DriverOptions{
-		endpoint: DefaultCSIEndpoint,
+		endpoint:            DefaultCSIEndpoint,
+		nifcloudSdkDebugLog: false,
 	}
 	for _, option := range options {
 		option(&driverOptions)
 	}
 
 	driver := Driver{
-		controllerService: newControllerService(instanceID),
-		nodeService:       newNodeService(instanceID),
+		controllerService: newControllerService(&driverOptions, instanceID),
+		nodeService:       newNodeService(&driverOptions, instanceID),
 		options:           &driverOptions,
 	}
 
@@ -101,6 +103,13 @@ func (d *Driver) Stop() {
 func WithEndpoint(endpoint string) func(*DriverOptions) {
 	return func(o *DriverOptions) {
 		o.endpoint = endpoint
+	}
+}
+
+// WithNifcloudSdkDebugLog sets the nifcloud sdk debug log
+func WithNifcloudSdkDebugLog(nifcloudSdkDebugLog bool) func(*DriverOptions) {
+	return func(o *DriverOptions) {
+		o.nifcloudSdkDebugLog = nifcloudSdkDebugLog
 	}
 }
 

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -63,8 +63,8 @@ type nodeService struct {
 
 // newNodeService creates a new node service
 // it panics if failed to create the service
-func newNodeService(instanceID string) nodeService {
-	cloud, err := cloud.NewCloud()
+func newNodeService(driverOptions *DriverOptions, instanceID string) nodeService {
+	cloud, err := cloud.NewCloud(driverOptions.nifcloudSdkDebugLog)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Summary

- Add option `--nifcloud-sdk-debug-log`
- Add chart value `controller.sdkDebugLog` and `node.sdkDebugLog`

## Review

- [x] All checks have passed
- [x] Check Results

## Results

### Log

####  --nifcloud-sdk-debug-log=true

```
    spec:
      containers:
      - args:
        - --endpoint=$(CSI_ENDPOINT)
        - --nifcloud-sdk-debug-log=true
        - --logtostderr
        - --v=2
```

```sh
$ kubectl logs -f -n kube-system nifcloud-additional-storage-csi-controller-6b499b645-jbwp5
Defaulted container "controller" out of: controller, csi-provisioner, csi-attacher, csi-resizer, liveness-probe
I0116 05:59:46.809531       1 driver.go:39] Driver: additional-storage.csi.nifcloud.com Version: v0.1.4-11-g5461a83-dirty
I0116 05:59:46.809749       1 mount_linux.go:164] Detected OS without systemd
I0116 05:59:46.810001       1 driver.go:91] Listening for connections on address: &net.UnixAddr{Name:"/var/lib/csi/sockets/pluginproxy/csi.sock", Net:"unix"}
SDK 2024/01/16 06:01:36 DEBUG Request
POST /api/ HTTP/1.1
Host: jp-east-1.computing.api.nifcloud.com
User-Agent: aws-sdk-go-v2/1.17.4 os/linux lang/go/1.20.7 md/GOOS/linux md/GOARCH/amd64 api/computing/1.19.1
Content-Length: 207
Amz-Sdk-Invocation-Id: a1fc0d1f-36b1-43ee-acd2-66a561e228e8
Amz-Sdk-Request: attempt=1; max=3
Content-Type: application/x-www-form-urlencoded
Accept-Encoding: gzip

AccessKeyId=<<<MASKED>>>&Action=DescribeVolumes&Signature=<<<MASKED>>>%2BWQaS0Js%3D&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp
=2024-01-16T06%3A01%3A36Z&Version=3.0
SDK 2024/01/16 06:01:38 DEBUG Response
HTTP/1.1 200 OK
Connection: close
Transfer-Encoding: chunked
Content-Type: text/xml;charset=utf-8
Date: Tue, 16 Jan 2024 06:01:38 GMT
Keep-Alive: timeout=5, max=100
Server: Apache
Vary: Accept-Encoding
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN, SAMEORIGIN
X-Xss-Protection: 1; mode=block

226a
<?xml version="1.0" encoding="UTF-8" standalone="yes"?><DescribeVolumesResponse xmlns="https://computing.api.nifcloud.com/api/">
...
```

####  empty --nifcloud-sdk-debug-log 

```
    spec:
      containers:
      - args:
        - --endpoint=$(CSI_ENDPOINT)
        - --logtostderr
        - --v=2
```

```sh
$ kubectl logs -n kube-system nifcloud-additional-storage-csi-controller-57fcc85884-mdvvs
Defaulted container "controller" out of: controller, csi-provisioner, csi-attacher, csi-resizer, liveness-probe
I0116 06:09:07.199021       1 driver.go:39] Driver: additional-storage.csi.nifcloud.com Version: v0.1.4-11-g5461a83-dirty
I0116 06:09:07.199252       1 mount_linux.go:164] Detected OS without systemd
I0116 06:09:07.199492       1 driver.go:91] Listening for connections on address: &net.UnixAddr{Name:"/var/lib/csi/sockets/pluginproxy/csi.sock", Net:"unix"}
I0116 06:13:50.055847       1 controller.go:123] create volume in east-12 zone
I0116 06:14:30.760333       1 controller.go:123] create volume in east-12 zone
```

### Chart

#### sdkDebugLog=true

```sh
$ helm template charts/nifcloud-additional-storage-csi-driver/ \
>     --set nifcloud.region=jp-east-1 \
>     --set nifcloud.accessKeyId.secretName=nifcloud-additional-storage-csi-secret \
>     --set nifcloud.accessKeyId.key=access_key_id \
>     --set nifcloud.secretAccessKey.secretName=nifcloud-additional-storage-csi-secret \
>     --set nifcloud.secretAccessKey.key=secret_access_key \
>     --set controller.sdkDebugLog=true \
>     --set node.sdkDebugLog=true \
>     | grep -A 6 -e "name: controller" -e "name: node-plugin"
        - name: node-plugin
          image: "ghcr.io/nifcloud/nifcloud-additional-storage-csi-driver:v0.1.0"
          imagePullPolicy: IfNotPresent
          args:
            - --endpoint=$(CSI_ENDPOINT)
            - --nifcloud-sdk-debug-log=true
            - --logtostderr
--
        - name: controller
          image: "ghcr.io/nifcloud/nifcloud-additional-storage-csi-driver:v0.1.0"
          imagePullPolicy: IfNotPresent
          args:
            - --endpoint=$(CSI_ENDPOINT)
            - --nifcloud-sdk-debug-log=true
            - --logtostderr
```

#### empty sdkDebugLog

```sh
$ helm template charts/nifcloud-additional-storage-csi-driver/ \
>     --set nifcloud.region=jp-east-1 \
>     --set nifcloud.accessKeyId.secretName=nifcloud-additional-storage-csi-secret \
>     --set nifcloud.accessKeyId.key=access_key_id \
>     --set nifcloud.secretAccessKey.secretName=nifcloud-additional-storage-csi-secret \
>     --set nifcloud.secretAccessKey.key=secret_access_key \
>     | grep -A 6 -e "name: controller" -e "name: node-plugin"
        - name: node-plugin
          image: "ghcr.io/nifcloud/nifcloud-additional-storage-csi-driver:v0.1.0"
          imagePullPolicy: IfNotPresent
          args:
            - --endpoint=$(CSI_ENDPOINT)
            - --logtostderr
            - --v=2
--
        - name: controller
          image: "ghcr.io/nifcloud/nifcloud-additional-storage-csi-driver:v0.1.0"
          imagePullPolicy: IfNotPresent
          args:
            - --endpoint=$(CSI_ENDPOINT)
            - --logtostderr
            - --v=2
```